### PR TITLE
Style/#17 - CollectionViewCell identifier Extension 추가

### DIFF
--- a/saftyReport/saftyReport/Resource/Extension/UICollectionViewCell+.swift
+++ b/saftyReport/saftyReport/Resource/Extension/UICollectionViewCell+.swift
@@ -1,0 +1,17 @@
+//
+//  UICollectionViewCell+.swift
+//  saftyReport
+//
+//  Created by OneTen on 11/19/24.
+//
+
+import UIKit
+
+extension UICollectionViewCell {
+    
+    // Cell identifier
+    static var cellIdentifier : String {
+        return String(describing: self)
+    }
+    
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
Connected: #17 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- CollectionViewCell 익스텐션을 추가했습니다

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`UICollectionViewCell+`
```swift
extension UICollectionViewCell {
    
    // Cell identifier
    static var cellIdentifier : String {
        return String(describing: self)
    }
    
}
```

사용할때는 `{cell}.cellIdentifier` 이런 식으로 사용하면 됩니다.


**예시**
```
collectionView.register(MyCustomCell.self, forCellWithReuseIdentifier: MyCustomCell.cellIdentifier)
```