### PR TITLE
Fix/#49 - .gitignore에 *.xcconfig 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,5 +140,6 @@ iOSInjectionProject/
 !*.xcworkspace/contents.xcworkspacedata
 /*.gcno
 **/xcshareddata/WorkspaceSettings.xcsettings
+*.xcconfig
 
 # End of https://www.toptal.com/developers/gitignore/api/xcode,swift,cocoapods,macos


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #49

## 📄 작업 내용
.gitignore에 `.xcconfig` 가 빠져있는 걸 발견했습니다.
그래서 마지막 줄에 `*.xcconfig`를 추가했습니다!

**참고> 현재는 아래 사진처럼 git이 Config 파일을 인식합니다.**
<img width="537" alt="image" src="https://github.com/user-attachments/assets/710fb91f-2670-4912-af8c-b6f69cd33e13">