### PR TITLE
[feat] 최종 비동기 코드로 전환

### DIFF
--- a/saftyReport/saftyReport/Source/ReportDetail/Cell/ContentCell.swift
+++ b/saftyReport/saftyReport/Source/ReportDetail/Cell/ContentCell.swift
@@ -10,7 +10,14 @@ import UIKit
 import SnapKit
 import Then
 
+protocol ContentCellDelegate: AnyObject {
+    func contentDidChange(_ text: String)
+}
+
 class ContentCell: BaseCell {
+    
+    weak var delegate: ContentCellDelegate?
+
     private let recommendationLabel = UILabel().then {
         $0.textColor = .primaryOrange
         let attributedText = NSAttributedString.styled(
@@ -136,6 +143,12 @@ class ContentCell: BaseCell {
         textCheckButton.addTarget(self, action: #selector(textCheckButtonTapped), for: .touchUpInside)
     }
     
+    func textViewDidChange(_ textView: UITextView) {
+        if textView.textColor != .lightGray {
+            delegate?.contentDidChange(textView.text)
+        }
+    }
+    
     @objc private func textCheckButtonTapped() {
         textCheckButton.isSelected.toggle()
         if textCheckButton.isSelected {
@@ -152,6 +165,8 @@ class ContentCell: BaseCell {
             }
         }
     }
+    
+    
 }
 
 extension ContentCell: UITextViewDelegate {

--- a/saftyReport/saftyReport/Source/ReportDetail/Cell/PhoneCell.swift
+++ b/saftyReport/saftyReport/Source/ReportDetail/Cell/PhoneCell.swift
@@ -11,7 +11,14 @@ import UIKit
 import SnapKit
 import Then
 
+protocol PhoneCellDelegate: AnyObject {
+    func phoneNumberDidChange(_ number: String)
+}
+
 class PhoneCell: BaseCell {
+    
+    weak var delegate: PhoneCellDelegate?
+    
     private let textField = UITextField().then {
         $0.backgroundColor = .gray3
         $0.layer.cornerRadius = 8
@@ -42,14 +49,17 @@ class PhoneCell: BaseCell {
     override func configure(with item: ReportDetailItem) {
         super.configure(with: item)
         
-        // placeholder에 스타일 적용
         let attributedPlaceholder = NSAttributedString.styled(
             text: item.placeholder ?? "",
             style: .body9,
             alignment: .left
         )
-            textField.attributedPlaceholder = attributedPlaceholder
+        textField.attributedPlaceholder = attributedPlaceholder
     }
+
+    @objc private func textFieldDidChange(_ textField: UITextField) {
+         delegate?.phoneNumberDidChange(textField.text ?? "")
+     }
 }
 
 #Preview {

--- a/saftyReport/saftyReport/Source/ReportDetail/Cell/ReportTypeCell.swift
+++ b/saftyReport/saftyReport/Source/ReportDetail/Cell/ReportTypeCell.swift
@@ -10,6 +10,10 @@ import UIKit
 import SnapKit
 import Then
 
+protocol ReportTypeCellDelegate: AnyObject {
+    func didToggleExpansion(isExpanded: Bool)
+}
+
 class ReportTypeCell: BaseCell {
     private let mockReportView = MockReportView()
     weak var delegate: ReportTypeCellDelegate?


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #77 

## 📄 작업 내용
- 각 배열에 값을 담아 최종코드로 전송합니다.
- 전체 코코드를 리팩토링햇습니다.
- 비동기 코드를 아주 빡세게 구현했습니다.

### 리팩토링된 부분을 좀더 좀더 자세하게 작성해보자면

1. 콜백 지옥 제거: 중첩된 클로저들을 async/await 구조로 변경했습니다.
2. 에러 처리 개선: try-catch를 사용한 명확한 에러 핸들링을 지정했습니다.
3. 타입 안전성 강화: async 함수들의 반환 타입을 명확히 지정했습니다.
4. 스레드 안전성 보장: @MainActor 사용으로 UI 업데이트의 안전성 확보했습니다(기존에 클로저 기반이였기에 터치 무시당함, 화면 딜레이표시의 이슈가 있었습니다)
5. 코드 가독성 향상: 비동기 작업들의 실행 순서를 명확하게 표현했습니다.(동기적 가독성)
6. 코드의 기능적 응집도 증가 : Extension이 하나의 명확한 책임을 가질수 있게되어 SOLID원칙의 SRP를 충분히 준수할 수 있게 되어 추후 아키텍쳐등의 유지보수에 충분한 이점을 가지게 되었습니다.

|    구현 내용    |   IPhone 15 pro   |   IPhone SE   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "" width ="250"> | <img src = "https://github.com/user-attachments/assets/cd267835-00b0-4f9c-9642-8736b574ce60" width ="250"> |

## 💻 주요 코드 설명
1. ReportService Actor 도입

```swift

actor ReportService {
    static let shared = ReportService()
    private init() {}

    func submitReport(_ report: ReportRequest) async throws -> ReportResponse {

    }
}
```

- Actor를 사용하여 thread-safe한 싱글톤 서비스 객체를 구현했습니다
- submitReport 메서드를 async throws로 선언하여 비동기 네트워크 요청과 에러 처리를 명시적으로 수행합니다
- withCheckedThrowingContinuation을 사용하여 Alamofire의 콜백 기반 API를 async/await 패턴으로 변환했습니다

2. Alert 처리 로직 개선

```swift
private func showSubmitConfirmationAlert() async -> Bool {
    return await withCheckedContinuation { continuation in
        let alertVC = BaseTwoButtonAlertViewController()
// ... alert 설정

        alertVC.alertView.confirmButton.addAction(
            UIAction { [weak alertVC] _ in
                alertVC?.dismiss(animated: true) {
                    continuation.resume(returning: true)
                }
            },
            for: .touchUpInside
        )
// ... cancel 버튼 설정
    }
}

```

- 모든 Alert 표시 로직을 async 함수로 변환하여 연속적인 플로우 처리가 가능하게 했습니다 (커밋기록에는 남지 않았으나 기존에는 따로 비동기 처리가 되지않아 동기적으로 response를 기다리고 다른 레이아웃이 잡힌 이후 다음 alert가 나오는 문제발생)
- `withCheckedContinuation`을 사용하여 버튼 액션의 콜백을 async/await로 변환했습니다.
- Alert의 결과를 Boolean이나 Void 타입으로 반환하여 호출부에서 쉽게 처리할 수 있게 했습니다.

3.제출 버튼 액션 플로우

```swift
submitButton.addAction(
    UIAction { [weak self] _ in
        Task { @MainActor in
            await self?.handleSubmit()
        }
    },
    for: .touchUpInside
)

private func handleSubmit() async {
    let shouldSubmit = await showSubmitConfirmationAlert()
    if shouldSubmit {
        await submitReport()
    }
}

```

- 버튼 액션을 Task로 감싸서 async 메서드 호출이 가능하게 했습니다
- @MainActor 어노테이션을 사용하여 UI 업데이트가 메인 스레드에서 실행되도록 구현했습니다.
- 연속적인 비동기 작업들을 await를 사용하여 순차적으로 처리했습니다.

4. 리포트 제출 로직

```swift

private func submitReport() async {
    do {
        let reportRequest = ReportRequest(/* ... */)
        let response = try await ReportService.shared.submitReport(reportRequest)

        if response.status == 201 {
            await showSuccessAlert()
        } else {
            await showErrorAlert(message: response.message ?? "오류가 발생했습니다")
        }
    } catch {
        await showErrorAlert(message: "네트워크 오류가 발생했습니다")
    }
}

```

- try await를 사용하여 네트워크 요청의 성공/실패의 가독성(?) 을 높였습니다.
- 에러 처리와 성공/실패에 따른 alert 표시를 순차적으로 처리합니다
- 모든 비동기 작업들을 순서대로 볼수 있게 되었답니다.

5. 오버레이 뷰 설정

```swift
private func setupOverlayView() {
    view.addSubview(overlayView)

    Task { @MainActor in
        try? await Task.sleep(nanoseconds: 300_000_000)
// ... 오버레이 뷰 설정
    }
}

```

- DispatchQueue.main.asyncAfter를 Task와 sleep으로 대체하여 좀더 있어보이게 되었습니다.
- @MainActor를 사용하여 UI 업데이트의 Thread-Safty를 보장했습니다.



## 👀 마지막으로 이야기해볼 점
마지막 PR이고 마지막 기능작업이기에 좀더 여러분들이 가져갔으면 좋겟는 부분인 비동기 코드를 많이 심화적으로 사용해 보았습니다.
점차적으로 알아가야할 비동기 처리와 Concurrency에 대해서도 여러분들이 나중에라도 예제처럼 볼 수 있게 억지로 도입을 해보았습니다.
저도 제대로 알지못하고 느낌적으로만 알고 있는부분들도 있어서 함께 공부하면 좋겟습니다.
지금은 이해가 안될수도 있는데 천천히 읽어보시고 공부를 한 뒤 나중에라도(기수 끝나고 해도 괜찮습니다) 질문을 주시면 코드에 대한 설명을 해드리겟습니다.
그리고 도저히 뭔소리인지도 모르실수도 있는데 이부분은 미미나.....를 하는 방향으로 생각해 보겟습니다.(진짜 생각만 할 수 있음)

추가로, 모든 PR은 지금 제가 작성한것, 혹은 그 이상으로 모든 부분에 대해서 서로간 코드의 align이 되어야 하는데 그저 approve에만 그치는 코드리뷰가 된것같아 조금은 아쉽지만 개인이 바빠서, 그리고 공부하기에도 많이 시간이 부족할것 같아 이부분까지는 따로 언급하지는 못했습니다. 이부분은 저도 많이 부족했었고 앞으로 개발을 하면서 서로간의 코드리뷰 문화를 도입해서 심화적으로 생각할 수 있는 기회로 도약할수 있었으면 좋겟습니다.

다들 합동세미나 어떠셧나요? 처음하는 협업이니 만큼 아쉬운 부분들도 분명히 있을거고 성장했던 부분들도 분명히 있을것이라 생각합니다.
저도 많이 아쉽고 좋았던 경험들이 있었는데 좀더 구체적인 이야기는 이후 회고때 더 자세하게 이야기 나누었으면 좋겟네요.
2주간의 경험이 바로 취업을 위한 경험이 되기는 어렵겟지만 여러분들이 더 멋진 개발자로 성장할수 있는 초석이 되었으면 좋겟습니다.

리드라고 하기에 모자라고 말도 안되는 저랑 같이 합동세미나 해주셔서 진심으로 고맙습니다.
앞으로도 즐겁게 개발해보아요!